### PR TITLE
Set tsfeatures as remote

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -12,6 +12,7 @@ URL: https://github.com/ykang/tsgeneration
 BugReports: https://github.com/ykang/tsgeneration/issues/
 Depends: R (>= 3.4.0)
 Imports: tsfeatures, doRNG, polynom, mvtnorm, forecast, dplyr, stats, tibble, utils, purrr, magrittr, shiny, GA, foreach, methods
+Remotes: robjhyndman/tsfeatures
 Suggests: fGarch
 NeedsCompilation: no
 License: GPL (>= 2)

--- a/README.md
+++ b/README.md
@@ -7,14 +7,6 @@ diverse and controllable characteristics.
 Installation
 ------------
 
-The package requires the `tsfeatures` package from [GitHub
-Repository](https://github.com/robjhyndman/tsfeatures) with:
-
-``` r
-# install.packages("devtools")
-devtools::install_github("robjhyndman/tsfeatures")
-```
-
 You can install the **development** version of `tsgeneration` package from [GitHub
 Repository](https://github.com/ykang/tsgeneration) with:
 


### PR DESCRIPTION
When installing using `devtools::install_github()`, the tsfeatures package can now be automatically installed if required.