### PR TITLE
Update Description: Fix License & VignetteBuilder

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Imports:
 Suggests: 
   fGarch
 NeedsCompilation: no
-License: GPLv3
+License: GPL-3+ file LICENSE
 Encoding: UTF-8
 RoxygenNote: 6.1.0
-VignetteBuilder: knitr
+VignetteBuilder: utils


### PR DESCRIPTION
1. Change from License: "GPLv3" to "License: GPL-3+ file LICENSE"
(To avoid warning and note)

2. Change from "VignetteBuilder: knitr" to "VignetteBuilder: utils"
(To avoid warning)