### PR TITLE
set parallel=FALSE & library(forecast)

### DIFF
--- a/vignettes/QuickStart.Rmd
+++ b/vignettes/QuickStart.Rmd
@@ -19,8 +19,7 @@ options(tibble.print_min = 5)
 ```
 
 ```{r, message=FALSE, include = FALSE}
-library(fpp3)
-library(parallel)
+library(forecast)
 ```
 
 ## About gratis
@@ -148,7 +147,9 @@ x <- generate_ts_with_target(
   n = 1, ts.length = 60, freq = 1, seasonal = 0,
                         features = c('entropy', 'stl_features'),
                       selected.features = c('entropy', 'trend'),
-                        target = c(0.6, 0.9))
+                        target = c(0.6, 0.9),  
+                        parallel=FALSE
+                        )
 ```
 
 **Plot time series**


### PR DESCRIPTION
1. set parallel=FALSE when using generate_ts_with_targe(), so R wouldn't require to lode library(doParallel)
2. use library(forecast) to load autoplot() not library(fpp3)