### PR TITLE
Namespaces in Imports field not imported from:   ‘rlang’ ‘shinydashbo…

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,13 +31,13 @@ Imports:
   GA,
   foreach,
   methods,
-  rlang,
-  shiny,
-  shinydashboard
+  shiny
 Suggests: 
     fGarch,
     knitr,
-    rmarkdown
+    rmarkdown,
+    rlang,
+    shinydashboard
 NeedsCompilation: no
 License: GPL-3
 Encoding: UTF-8


### PR DESCRIPTION
…ard’

Move rlang and shinydashboard to the Suggests section of the description file.

To solve this problem:
checking dependencies in R code ... NOTE
Namespaces in Imports field not imported from:
  ‘rlang’ ‘shinydashboard’
  All declared Imports should be used.